### PR TITLE
state collision fix

### DIFF
--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1000,6 +1000,9 @@ class Home extends Component {
                             this.metricFilterSearchBarRef.current?.setValue('');
                             
                         }} ref={this.metricFilterSearchBarRef} placeholder="Local metric filter (regex)" style={{ width: 400, alignSelf: 'center', borderBottomRightRadius: 0, borderBottomLeftRadius: 0, fontFamily: 'Mono', fontWeight: 'bold' }} onChangeText={text => {
+
+                            if (this.state.forceLoading) return;
+
                             clearTimeout(this.clientMetricFilterTimeout);
                             
                             this.clientMetricFilterTimeout = setTimeout(() => {
@@ -1012,6 +1015,8 @@ class Home extends Component {
                         <AppTextInput noClickAction={true} action="cloud-upload" actionDoneIcon="cloud-done-outline" actionLoading={this.state.metricServerFilterLoading} actionComplete={this.state.metricServerFilterComplete} onAction={async () => {
                             this.sendServerFilter();
                         }} ref={this.metricServerFilterSearchBarRef} placeholder="Cloud metric filter (regex)" style={{ width: 400, alignSelf: 'center', borderTop: 0, borderTopRightRadius: 0, borderTopLeftRadius: 0, fontFamily: 'Mono', fontWeight: 'bold'}} onChangeText={text => {
+
+                            if (this.state.forceLoading) return;
 
                             clearTimeout(this.serverMetricFilterTimeout);
 


### PR DESCRIPTION
Starting the thread about fixing the state collision to do with updating the filters on-load. Ultimately, the filter text inputs need to be reworked. However, let's create a quick patch now, and then fix the inputs later.

@simontuffs can you test out these changes in the cloud?

Will keep adding on commits as we fine tune the patch.

Wanting to base this fix off of master, after which we can apply to other branches like double-filter.